### PR TITLE
macOS take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ API is attempted to be consistent with [libuv API](http://docs.libuv.org/en/v1.x
 
 ### Suuported Platforms
 * Linux
-* _Darwin/MacOS - future_
+* _Darwin/MacOS
 * _Windows - future_
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ API is attempted to be consistent with [libuv API](http://docs.libuv.org/en/v1.x
 
 ### Suuported Platforms
 * Linux
-* _Darwin/MacOS
+* Darwin/MacOS
 * _Windows - future_
 
 

--- a/src/bio.c
+++ b/src/bio.c
@@ -12,21 +12,21 @@ struct msg {
     size_t len;
     uint8_t *buf;
 
-    SIMPLEQ_ENTRY(msg) next;
+    STAILQ_ENTRY(msg) next;
 };
 
 BIO *BIO_new() {
     BIO* bio = calloc(1, sizeof(BIO));
     bio->available = 0;
     bio->headoffset = 0;
-    SIMPLEQ_INIT(&bio->message_q);
+    STAILQ_INIT(&bio->message_q);
     return bio;
 }
 
 void BIO_free(BIO* b) {
-    while(!SIMPLEQ_EMPTY(&b->message_q)) {
-        struct msg *m = SIMPLEQ_FIRST(&b->message_q);
-        SIMPLEQ_REMOVE_HEAD(&b->message_q, next);
+    while(!STAILQ_EMPTY(&b->message_q)) {
+        struct msg *m = STAILQ_FIRST(&b->message_q);
+        STAILQ_REMOVE_HEAD(&b->message_q, next);
         free(m->buf);
         free(m);
     }
@@ -45,15 +45,15 @@ void BIO_put(BIO *bio, const uint8_t *buf, size_t len) {
     memcpy(m->buf, buf, len);
     bio->available += len;
 
-    SIMPLEQ_INSERT_TAIL(&bio->message_q, m, next);
+    STAILQ_INSERT_TAIL(&bio->message_q, m, next);
 }
 
 int BIO_read(BIO *bio, uint8_t *buf, size_t len) {
-    if (SIMPLEQ_EMPTY(&bio->message_q)) {
+    if (STAILQ_EMPTY(&bio->message_q)) {
         return -1;
     }
 
-    struct msg *m = SIMPLEQ_FIRST(&bio->message_q);
+    struct msg *m = STAILQ_FIRST(&bio->message_q);
 
     size_t recv_size = MIN(len, m->len - bio->headoffset);
     memcpy(buf, m->buf + bio->headoffset, recv_size);
@@ -61,7 +61,7 @@ int BIO_read(BIO *bio, uint8_t *buf, size_t len) {
     bio->available -= recv_size;
 
     if (bio->headoffset == m->len) {
-        SIMPLEQ_REMOVE_HEAD(&bio->message_q, next);
+        STAILQ_REMOVE_HEAD(&bio->message_q, next);
         bio->headoffset = 0;
 
         free(m->buf);
@@ -70,5 +70,3 @@ int BIO_read(BIO *bio, uint8_t *buf, size_t len) {
 
     return (int) recv_size;
 }
-
-

--- a/src/bio.h
+++ b/src/bio.h
@@ -7,20 +7,10 @@
 
 #include <sys/queue.h>
 
-#if defined(__APPLE__)
-#define SIMPLEQ_INIT        STAILQ_INIT
-#define SIMPLEQ_HEAD        STAILQ_HEAD
-#define SIMPLEQ_ENTRY       STAILQ_ENTRY
-#define SIMPLEQ_EMPTY       STAILQ_EMPTY
-#define SIMPLEQ_FIRST       STAILQ_FIRST
-#define SIMPLEQ_INSERT_TAIL STAILQ_INSERT_TAIL
-#define SIMPLEQ_REMOVE_HEAD STAILQ_REMOVE_HEAD
-#endif
-
 typedef struct bio {
     size_t available;
     size_t headoffset;
-    SIMPLEQ_HEAD(msgq, msg) message_q;
+    STAILQ_HEAD(msgq, msg) message_q;
 } BIO;
 
 BIO* BIO_new();


### PR DESCRIPTION
The STAILQ macros exist on Linux as well as macOS, so use them and remove the compatibility macros.