### PR TITLE
initial TLS engine API/implementation(with mbedTLS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ add_subdirectory(libuv)
 set_target_properties(uv_a PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/libuv/include)
 
-add_library(uv_mbed STATIC src/uv_mbed.c src/uv_mbed.c src/bio.c src/bio.h)
+add_library(uv_mbed STATIC src/uv_mbed.c src/uv_mbed.c src/bio.c src/bio.h src/engine_mbedtls.c include/uv_mbed/tls_engine.h)
 
 if (WIN32)
     target_include_directories(uv_mbed PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/win32/include)

--- a/include/uv_mbed/tls_engine.h
+++ b/include/uv_mbed/tls_engine.h
@@ -1,0 +1,95 @@
+//
+// Created by eugene on 8/12/19.
+//
+
+#ifndef UV_MBED_TLS_ENGINE_H
+#define UV_MBED_TLS_ENGINE_H
+
+#include <stdlib.h>
+
+typedef enum tls_handshake_st {
+    TLS_HS_CONTINUE,
+    TLS_HS_COMPLETE,
+    TLS_HS_ERROR
+} tls_handshake_state;
+
+enum TLS_RESULT {
+    TLS_OK = 0,
+    TLS_ERR = -1,
+    TLS_EOF = -2,
+    TLS_READ_AGAIN = -3,
+    TLS_MORE_AVAILABLE = -4,
+};
+
+typedef struct {
+    /**
+     * Initiates/continues TLS handshake.
+     * @param engine
+     * @param in data received from TSL peer
+     * @param in_bytes number of bytes in inbound buffer
+     * @param out data to be send to TLS peer
+     * @param out_bytes number of bytes to be sent
+     * @param maxout outbound buffer size
+     */
+    tls_handshake_state
+    (*handshake)(void *engine, char *in, size_t in_bytes, char *out, size_t *out_bytes, size_t maxout);
+
+    /**
+     * Genereate TSL close notify.
+     * @param engine
+     * @param out outbound buffer
+     * @param out_bytes number of outbound bytes written
+     * @param maxout size of outbound buffer
+     */
+    int (*close)(void *engine, char *out, size_t *out_bytes, size_t maxout);
+
+    /**
+      * wraps application data into ssl stream format, out bound buffer contains bytes to be sent to TSL peer
+      * @param engine
+      * @param data
+      * @param data_len
+      * @param out
+      * @param out_bytes
+      * @param maxout
+      */
+    int (*write)(void *engine, const char *data, size_t data_len, char *out, size_t *out_bytes, size_t maxout);
+
+    /**
+     * process bytes received from TLS peer. Application data is placed in out buffer.
+     * @param engine
+     * @param ssl_in bytes received from TLS peer
+     * @param ssl_in_len number of bytes received
+     * @param out buffer for application data
+     * @param out_bytes number of bytes received
+     * @param maxout size of out buffer
+     */
+    int (*read)(void *engine, const char *ssl_in, size_t ssl_in_len, char *out, size_t *out_bytes, size_t maxout);
+
+    int (*strerror)(void *engine, char *err_out, size_t out_len);
+} tls_engine_api;
+
+typedef struct {
+    void *engine;
+    tls_engine_api *api;
+} tls_engine;
+
+typedef struct tls_context_s tls_context;
+
+typedef struct {
+    void (*set_own_cert)(void *ctx, const char *cert_buf, size_t cert_len, const char *key_buf, size_t key_len);
+
+    tls_engine *(*new_engine)(void *ctx, const char *host);
+
+    void (*free_ctx)(tls_context *ctx);
+
+    void (*free_engine)(tls_engine *);
+} tls_context_api;
+
+struct tls_context_s {
+    void *ctx;
+    tls_context_api *api;
+};
+
+tls_context *default_tls_context(const char *ca, size_t ca_len);
+
+#endif //UV_MBED_TLS_ENGINE_H

--- a/include/uv_mbed/uv_mbed.h
+++ b/include/uv_mbed/uv_mbed.h
@@ -7,6 +7,9 @@
 
 #include <uv.h>
 #include <mbedtls/ssl.h>
+#include <stdbool.h>
+
+#include "tls_engine.h"
 
 /*sets the mbed tls debug threshold*/
 void uv_mbed_mbedtls_debug_set_threshold(int threshold);
@@ -14,7 +17,7 @@ void uv_mbed_mbedtls_debug_set_threshold(int threshold);
 typedef struct uv_mbed_s uv_mbed_t;
 typedef struct bio BIO;
 
-int uv_mbed_init(uv_loop_t *l, uv_mbed_t *mbed);
+int uv_mbed_init(uv_loop_t *l, uv_mbed_t *mbed, tls_context *tls);
 int uv_mbed_set_ca(uv_mbed_t *mbed, mbedtls_x509_crt* ca);
 int uv_mbed_set_cert(uv_mbed_t *mbed, mbedtls_x509_crt *cert, mbedtls_pk_context *privkey);
 int uv_mbed_keepalive(uv_mbed_t *mbed, int keepalive, unsigned int delay);

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -2,3 +2,7 @@ add_executable(sample sample.c)
 
 target_link_libraries(sample PUBLIC uv_mbed)
 target_include_directories(sample PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+add_executable(engine_test engine_test.c)
+target_link_libraries(engine_test PUBLIC uv_mbed)
+target_include_directories(engine_test PUBLIC ${CMAKE_SOURCE_DIR}/include)

--- a/sample/engine_test.c
+++ b/sample/engine_test.c
@@ -1,0 +1,122 @@
+//
+// Created by eugene on 8/8/19.
+//
+
+#include <netdb.h>
+#include <zconf.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <uv_mbed/uv_mbed.h>
+
+#define HOST "wttr.in"
+
+tls_context *new_mbedtls_ctx(const char *ca, size_t ca_len);
+
+int main(int argc, char **argv) {
+    struct hostent *he = gethostbyname(HOST);
+
+    char ip[1000];
+    struct in_addr **addr = (struct in_addr **) he->h_addr_list;
+    for (int i = 0; addr[i] != NULL; i++) {
+        strcpy(ip, inet_ntoa(*addr[i]));
+    }
+
+    printf("ip: %s\n", ip);
+
+    tls_context *tls = new_mbedtls_ctx(NULL, 0);
+    tls_engine *engine = tls->api->new_engine(tls->ctx, HOST);
+
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+
+    struct sockaddr_in address;
+    int opt = 1;
+    int addrlen = sizeof(address);
+
+    // Forcefully attaching socket to the port 8080
+    if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT,
+                   &opt, sizeof(opt))) {
+        perror("setsockopt");
+    }
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = inet_addr(ip);
+    address.sin_port = htons(443);
+
+    if (connect(sock, (const struct sockaddr *) &address, addrlen) != 0) {
+        perror("failed to connect");
+        printf("connection with the server failed...\n");
+        exit(0);
+    }
+    else {
+        printf("connected\n");
+    }
+
+    // do handshake
+    char ssl_in[32 * 1024];
+    char ssl_out[32 * 1024];
+    size_t in_bytes = 0;
+    size_t out_bytes = 0;
+
+    int i = 0;
+    do {
+        tls_handshake_state state = engine->api->handshake(engine->engine, ssl_in, in_bytes, ssl_out, &out_bytes,
+                                                           sizeof(ssl_out));
+
+        if (state == TLS_HS_COMPLETE) {
+            printf("handshake complete\n");
+            break;
+        }
+        else if (state == TLS_HS_ERROR) {
+            fprintf(stderr, "handshake failed\n");
+            exit(1);
+        }
+
+        printf("hs: out_bytes=%zd, state=%x\n", out_bytes, state);
+        if (out_bytes > 0) {
+            size_t wrote = write(sock, ssl_out, out_bytes);
+            printf("hs: wrote_bytes=%zd\n", wrote);
+        }
+
+        in_bytes = read(sock, ssl_in, sizeof(ssl_in));
+        printf("hs: in_bytes=%zd\n", in_bytes);
+    } while (true);
+
+    const char *req = "GET /Charlotte HTTP/1.1\n"
+                      "Accept: */*\n"
+                      "Accept-Enconding: plain\n"
+                      "Connection: keep-alive\n"
+                      "Host: " HOST "\n"
+                      "User-Agent: HTTPie/1.0.2\n"
+                      "\n";
+
+    engine->api->write(engine->engine, req, strlen(req), ssl_out, &out_bytes, sizeof(ssl_out));
+    printf("writing req=%zd bytes\n", out_bytes);
+    write(sock, ssl_out, out_bytes);
+
+    char resp[128];
+    size_t resp_read = 0;
+
+    int read_res = 0;
+    do {
+        if (read_res == 0 || read_res == TLS_READ_AGAIN) {
+            in_bytes = read(sock, ssl_in, sizeof(ssl_in));
+            printf("read resp=%zd bytes\n", in_bytes);
+        }
+        else {
+            in_bytes = 0;
+        }
+
+        read_res = engine->api->read(engine->engine, ssl_in, in_bytes, resp, &resp_read, sizeof(resp));
+        printf("%*.*s", (int) resp_read, (int) resp_read, resp);
+    } while (read_res == TLS_READ_AGAIN || read_res == TLS_MORE_AVAILABLE);
+
+    engine->api->close(engine->engine, ssl_out, &out_bytes, sizeof(ssl_out));
+    write(sock, ssl_out, out_bytes);
+
+    close(sock);
+
+    tls->api->free_engine(engine);
+    tls->api->free_ctx(tls);
+}
+

--- a/sample/sample.c
+++ b/sample/sample.c
@@ -14,6 +14,8 @@
 
 #define DEFAULT_CA_CHAIN "/etc/ssl/certs/ca-certificates.crt"
 
+int uv_mbed_sample_prep_ca(mbedtls_x509_crt *my_ca_chain);
+
 static void alloc(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) {
     buf->base = (char*) malloc(suggested_size);
     buf->len = suggested_size;
@@ -74,7 +76,7 @@ int main() {
     uv_loop_t* l = uv_default_loop();
 
     uv_mbed_t mbed;
-    uv_mbed_init(l, &mbed);
+    uv_mbed_init(l, &mbed, NULL);
 
     //sets debug output if needed
     //uv_mbed_mbedtls_debug_set_threshold(1);

--- a/src/engine_mbedtls.c
+++ b/src/engine_mbedtls.c
@@ -1,0 +1,292 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/debug.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/error.h>
+#include <uv_mbed/uv_mbed.h>
+#include "bio.h"
+
+// inspired by https://golang.org/src/crypto/x509/root_linux.go
+// Possible certificate files; stop after finding one.
+const char *const caFiles[] = {
+        "/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+        "/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+        "/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+        "/etc/pki/tls/cacert.pem",                           // OpenELEC
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+        "/etc/ssl/cert.pem"                                  // macOS
+};
+#define NUM_CAFILES (sizeof(caFiles) / sizeof(char *))
+
+struct mbedtls_context {
+    mbedtls_ssl_config config;
+    mbedtls_pk_context *own_key;
+    mbedtls_x509_crt *own_cert;
+};
+struct mbedtls_engine {
+    mbedtls_ssl_context *ssl;
+    BIO *in;
+    BIO *out;
+};
+
+void mbedtls_set_own_cert(void *ctx, const char *cert_buf, size_t cert_len, const char *key_buf, size_t key_len);
+
+static tls_engine *new_mbedtls_engine(void *ctx, const char *host);
+
+static tls_handshake_state
+mbedtls_continue_hs(void *engine, char *in, size_t in_bytes, char *out, size_t *out_bytes, size_t maxout);
+
+static int mbedtls_write(void *engine, const char *data, size_t data_len, char *out, size_t *out_bytes, size_t maxout);
+
+static int
+mbedtls_read(void *engine, const char *ssl_in, size_t ssl_in_len, char *out, size_t *out_bytes, size_t maxout);
+
+static int mbedtls_close(void *engine, char *out, size_t *out_bytes, size_t maxout);
+
+static void mbedtls_free(tls_engine *engine);
+
+static void mbedtls_free_ctx(tls_context *ctx);
+
+static tls_context_api mbedtls_context_api = {
+        .set_own_cert = mbedtls_set_own_cert,
+        .new_engine = new_mbedtls_engine,
+        .free_engine = mbedtls_free,
+        .free_ctx = mbedtls_free_ctx,
+};
+
+static tls_engine_api mbedtls_engine_api = {
+        .handshake = mbedtls_continue_hs,
+        .close = mbedtls_close,
+        .write = mbedtls_write,
+        .read = mbedtls_read,
+};
+
+
+static void init_ssl_context(mbedtls_ssl_config *ssl_config, const char *ca, size_t cabuf_len);
+
+static int mbed_ssl_recv(void *ctx, uint8_t *buf, size_t len);
+
+static int mbed_ssl_send(void *ctx, const uint8_t *buf, size_t len);
+
+extern tls_context *new_mbedtls_ctx(const char *ca, size_t ca_len) {
+    tls_context *ctx = calloc(1, sizeof(tls_context));
+    ctx->api = &mbedtls_context_api;
+    struct mbedtls_context *c = calloc(1, sizeof(struct mbedtls_context));
+    init_ssl_context(&c->config, ca, ca_len);
+    ctx->ctx = c;
+
+    return ctx;
+}
+
+static void tls_debug_f(void *ctx, int level, const char *file, int line, const char *str);
+
+static void init_ssl_context(mbedtls_ssl_config *ssl_config, const char *cabuf, size_t cabuf_len) {
+    char *tls_debug = getenv("MBEDTLS_DEBUG");
+    if (tls_debug != NULL) {
+        int level = (int) strtol(tls_debug, NULL, 10);
+        mbedtls_debug_set_threshold(level);
+    }
+
+
+    mbedtls_ssl_config_init(ssl_config);
+    mbedtls_ssl_conf_dbg(ssl_config, tls_debug_f, stdout);
+    mbedtls_ssl_config_defaults(ssl_config,
+                                MBEDTLS_SSL_IS_CLIENT,
+                                MBEDTLS_SSL_TRANSPORT_STREAM,
+                                MBEDTLS_SSL_PRESET_DEFAULT);
+    mbedtls_ssl_conf_authmode(ssl_config, MBEDTLS_SSL_VERIFY_REQUIRED);
+    mbedtls_ctr_drbg_context *drbg = calloc(1, sizeof(mbedtls_ctr_drbg_context));
+    mbedtls_entropy_context *entropy = calloc(1, sizeof(mbedtls_entropy_context));
+    mbedtls_ctr_drbg_init(drbg);
+    mbedtls_entropy_init(entropy);
+    unsigned char *seed = malloc(MBEDTLS_ENTROPY_MAX_SEED_SIZE); // uninitialized memory
+    mbedtls_ctr_drbg_seed(drbg, mbedtls_entropy_func, entropy, seed, MBEDTLS_ENTROPY_MAX_SEED_SIZE);
+    mbedtls_ssl_conf_rng(ssl_config, mbedtls_ctr_drbg_random, drbg);
+    mbedtls_x509_crt *ca = calloc(1, sizeof(mbedtls_x509_crt));
+    mbedtls_x509_crt_init(ca);
+
+    if (cabuf != NULL) {
+        int rc = mbedtls_x509_crt_parse(ca, cabuf, cabuf_len);
+        if (rc < 0) {
+            char err[1024];
+            mbedtls_strerror(rc, err, sizeof(err));
+            fprintf(stderr, "%s\n", err);
+            mbedtls_x509_crt_init(ca);
+
+            rc = mbedtls_x509_crt_parse_file(ca, cabuf);
+            mbedtls_strerror(rc, err, sizeof(err));
+            fprintf(stderr, "%s\n", err);
+        }
+    }
+    else {
+        for (int i = 0; i < NUM_CAFILES; i++) {
+            if (access(caFiles[i], R_OK) != -1) {
+                mbedtls_x509_crt_parse_file(ca, caFiles[i]);
+                break;
+            }
+        }
+    }
+
+
+    mbedtls_ssl_conf_ca_chain(ssl_config, ca, NULL);
+    free(seed);
+}
+
+static tls_engine *new_mbedtls_engine(void *ctx, const char *host) {
+    struct mbedtls_context *context = ctx;
+    mbedtls_ssl_context *ssl = calloc(1, sizeof(mbedtls_ssl_context));
+    mbedtls_ssl_init(ssl);
+    mbedtls_ssl_setup(ssl, &context->config);
+    mbedtls_ssl_set_hostname(ssl, host);
+    if (context->own_key != NULL) {
+        mbedtls_ssl_set_hs_own_cert(ssl, context->own_cert, context->own_key);
+    }
+
+    tls_engine *engine = calloc(1, sizeof(tls_engine));
+    struct mbedtls_engine *mbed_eng = calloc(1, sizeof(struct mbedtls_engine));
+    engine->engine = mbed_eng;
+    mbed_eng->ssl = ssl;
+    mbed_eng->in = BIO_new(0);
+    mbed_eng->out = BIO_new(0);
+    mbedtls_ssl_set_bio(ssl, mbed_eng, mbed_ssl_send, mbed_ssl_recv, NULL);
+    engine->api = &mbedtls_engine_api;
+
+    return engine;
+}
+
+static void mbedtls_free_ctx(tls_context *ctx) {
+    struct mbedtls_context *c = ctx->ctx;
+    mbedtls_x509_crt_free(c->config.ca_chain);
+    free(c->config.ca_chain);
+    mbedtls_ctr_drbg_context *drbg = c->config.p_rng;
+    mbedtls_entropy_free(drbg->p_entropy);
+    free(drbg->p_entropy);
+    mbedtls_ctr_drbg_free(drbg);
+    free(drbg);
+
+    mbedtls_ssl_config_free(&c->config);
+    free(c);
+    free(ctx);
+}
+
+static void mbedtls_free(tls_engine *engine) {
+    struct mbedtls_engine *e = engine->engine;
+    BIO_free(e->in);
+    BIO_free(e->out);
+
+    mbedtls_ssl_free(e->ssl);
+    free(e->ssl);
+    free(e);
+    free(engine);
+}
+
+void mbedtls_set_own_cert(void *ctx, const char *cert_buf, size_t cert_len, const char *key_buf, size_t key_len) {
+    struct mbedtls_context *c = ctx;
+    c->own_key = calloc(1, sizeof(mbedtls_pk_context));
+    int rc = mbedtls_pk_parse_key(c->own_key, key_buf, key_len, NULL, 0);
+    if (rc < 0) {
+        rc = mbedtls_pk_parse_keyfile(c->own_key, key_buf, NULL);
+    }
+
+    c->own_cert = calloc(1, sizeof(mbedtls_x509_crt));
+    rc = mbedtls_x509_crt_parse(c->own_cert, cert_buf, cert_len);
+    if (rc < 0) {
+        rc = mbedtls_x509_crt_parse_file(c->own_cert, cert_buf);
+    }
+}
+
+static void tls_debug_f(void *ctx, int level, const char *file, int line, const char *str) {
+    ((void) level);
+    printf("%s:%04d: %s", file, line, str);
+    fflush(stdout);
+}
+
+static tls_handshake_state
+mbedtls_continue_hs(void *engine, char *in, size_t in_bytes, char *out, size_t *out_bytes, size_t maxout) {
+    struct mbedtls_engine *eng = (struct mbedtls_engine *) engine;
+    if (in_bytes > 0) {
+        BIO_put(eng->in, in, in_bytes);
+    }
+    int state = mbedtls_ssl_handshake(eng->ssl);
+    char err[1024];
+    mbedtls_strerror(state, err, 1024);
+    *out_bytes = BIO_read(eng->out, out, maxout);
+
+    printf("hs_state = %d(%s), out_bytes = %zd\n", eng->ssl->state, err, *out_bytes);
+
+    if (eng->ssl->state == MBEDTLS_SSL_HANDSHAKE_OVER) {
+        return TLS_HS_COMPLETE;
+    }
+    else if (state == MBEDTLS_ERR_SSL_WANT_READ || state == MBEDTLS_ERR_SSL_WANT_WRITE) {
+        return TLS_HS_CONTINUE;
+    }
+    else {
+        return TLS_HS_ERROR;
+    }
+}
+
+static int mbedtls_write(void *engine, const char *data, size_t data_len, char *out, size_t *out_bytes, size_t maxout) {
+    struct mbedtls_engine *eng = (struct mbedtls_engine *) engine;
+    if (data_len > 0) {
+        mbedtls_ssl_write(eng->ssl, data, data_len);
+    }
+    *out_bytes = BIO_read(eng->out, out, maxout);
+    return 0;
+}
+
+static int
+mbedtls_read(void *engine, const char *ssl_in, size_t ssl_in_len, char *out, size_t *out_bytes, size_t maxout) {
+    struct mbedtls_engine *eng = (struct mbedtls_engine *) engine;
+    if (ssl_in_len > 0) {
+        BIO_put(eng->in, ssl_in, ssl_in_len);
+    }
+
+    int rc = mbedtls_ssl_read(eng->ssl, out, maxout);
+
+    if (rc == MBEDTLS_ERR_SSL_WANT_READ) {
+        return TLS_READ_AGAIN;
+    }
+
+    if (rc == 0) {
+        return TLS_EOF;
+    }
+    if (rc < 0) {
+        char err[1024];
+        mbedtls_strerror(rc, err, 1024);
+        printf("read = %d(%s)", rc, err);
+        return TLS_ERR; // TODO
+    }
+
+    *out_bytes = rc;
+    if (BIO_available(eng->in) > 0 || mbedtls_ssl_check_pending(eng->ssl)) {
+        return TLS_MORE_AVAILABLE;
+    }
+
+    return TLS_OK;
+}
+
+static int mbedtls_close(void *engine, char *out, size_t *out_bytes, size_t maxout) {
+    struct mbedtls_engine *eng = (struct mbedtls_engine *) engine;
+    mbedtls_ssl_close_notify(eng->ssl); // TODO handle error
+
+    *out_bytes = BIO_read(eng->out, out, maxout);
+    return 0;
+}
+
+static int mbed_ssl_recv(void *ctx, uint8_t *buf, size_t len) {
+    struct mbedtls_engine *eng = ctx;
+    if (BIO_available(eng->in) == 0) {
+        return MBEDTLS_ERR_SSL_WANT_READ;
+    }
+
+    return BIO_read(eng->in, buf, len);
+}
+
+static int mbed_ssl_send(void *ctx, const uint8_t *buf, size_t len) {
+    struct mbedtls_engine *eng = ctx;
+    BIO *out = eng->out;
+    BIO_put(out, buf, len);
+    return (int) len;
+}

--- a/src/uv_mbed.c
+++ b/src/uv_mbed.c
@@ -59,7 +59,7 @@ struct tcp_write_ctx {
 };
 
 
-int uv_mbed_init(uv_loop_t *l, uv_mbed_t *mbed) {
+int uv_mbed_init(uv_loop_t *l, uv_mbed_t *mbed, tls_context *tls) {
 #if _WIN32
     uv_stream_init_dup(l, (uv_stream_t*)mbed, UV_STREAM);
 #else


### PR DESCRIPTION
The goal of these changes is to allow replacement of default TLS library(mbedTLS) with other TLS implementations. To achieve that goal an abstraction layer is created consisting of `tls_context` and `tls_engine`